### PR TITLE
Clean skill keywords handling and add training helper

### DIFF
--- a/src/utils/cv_processor.py
+++ b/src/utils/cv_processor.py
@@ -15,9 +15,57 @@ import pandas as pd
 
 class CVProcessor:
     """Procesador simplificado de CVs"""
-    
-    def __init__(self):
+
+    DEFAULT_SKILL_KEYWORDS = [
+        # Tecnología
+        'python', 'java', 'javascript', 'sql', 'html', 'css', 'react', 'angular',
+        'node.js', 'php', 'c++', 'c#', '.net', 'spring', 'django', 'flask',
+        'git', 'docker', 'kubernetes', 'aws', 'azure', 'linux', 'windows',
+
+        # Data Science
+        'machine learning', 'deep learning', 'tensorflow', 'pytorch', 'pandas',
+        'numpy', 'scikit-learn', 'tableau', 'power bi', 'excel', 'r',
+        'statistics', 'data analysis', 'big data', 'hadoop', 'spark',
+
+        # Marketing
+        'marketing digital', 'seo', 'sem', 'google ads', 'facebook ads',
+        'social media', 'content marketing', 'email marketing', 'analytics',
+        'photoshop', 'illustrator', 'canva', 'hootsuite',
+
+        # Diseño
+        'diseño gráfico', 'ui/ux', 'figma', 'sketch', 'adobe creative',
+        'after effects', 'premiere', 'indesign', 'branding', 'tipografía',
+
+        # Ventas
+        'ventas', 'sales', 'crm', 'salesforce', 'negociación', 'prospección',
+        'atención al cliente', 'customer service', 'retail',
+
+        # Administración
+        'administración', 'gestión', 'management', 'liderazgo', 'proyectos',
+        'planificación', 'presupuestos', 'finanzas', 'contabilidad', 'rrhh',
+
+        # Agricultura
+        'agricultura', 'agronomía', 'cultivos', 'riego', 'fertilizantes',
+        'pesticidas', 'maquinaria agrícola', 'ganadería', 'veterinaria',
+        'producción agrícola', 'agropecuario', 'campo'
+    ]
+
+    def __init__(self, skill_keywords=None):
+        """Inicializa el procesador.
+
+        Parameters
+        ----------
+        skill_keywords : list[str] or None
+            Lista de palabras clave para detectar habilidades en el texto. Si se
+            pasa ``None`` se usa la lista por defecto. Una lista vacía desactiva
+            la detección de habilidades.
+        """
         self.supported_formats = ['.pdf', '.docx', '.doc', '.jpg', '.jpeg', '.png', '.bmp', '.tiff']
+        # Permitir personalizar las keywords de habilidades o deshabilitarlas
+        if skill_keywords is None:
+            self.skill_keywords = self.DEFAULT_SKILL_KEYWORDS
+        else:
+            self.skill_keywords = skill_keywords
     
     def extract_text_from_file(self, file_path):
         """Extrae texto de un archivo según su formato"""
@@ -151,42 +199,8 @@ class CVProcessor:
             if keyword in text:
                 features['education_keywords'].append(keyword)
         
-        # Keywords de habilidades por profesión
-        skill_keywords = [
-            # Tecnología
-            'python', 'java', 'javascript', 'sql', 'html', 'css', 'react', 'angular',
-            'node.js', 'php', 'c++', 'c#', '.net', 'spring', 'django', 'flask',
-            'git', 'docker', 'kubernetes', 'aws', 'azure', 'linux', 'windows',
-            
-            # Data Science
-            'machine learning', 'deep learning', 'tensorflow', 'pytorch', 'pandas',
-            'numpy', 'scikit-learn', 'tableau', 'power bi', 'excel', 'r',
-            'statistics', 'data analysis', 'big data', 'hadoop', 'spark',
-            
-            # Marketing
-            'marketing digital', 'seo', 'sem', 'google ads', 'facebook ads',
-            'social media', 'content marketing', 'email marketing', 'analytics',
-            'photoshop', 'illustrator', 'canva', 'hootsuite',
-            
-            # Diseño
-            'diseño gráfico', 'ui/ux', 'figma', 'sketch', 'adobe creative',
-            'after effects', 'premiere', 'indesign', 'branding', 'tipografía',
-            
-            # Ventas
-            'ventas', 'sales', 'crm', 'salesforce', 'negociación', 'prospección',
-            'atención al cliente', 'customer service', 'retail',
-            
-            # Administración
-            'administración', 'gestión', 'management', 'liderazgo', 'proyectos',
-            'planificación', 'presupuestos', 'finanzas', 'contabilidad', 'rrhh',
-            
-            # Agricultura
-            'agricultura', 'agronomía', 'cultivos', 'riego', 'fertilizantes',
-            'pesticidas', 'maquinaria agrícola', 'ganadería', 'veterinaria',
-            'producción agrícola', 'agropecuario', 'campo'
-        ]
-        
-        for skill in skill_keywords:
+        # Keywords de habilidades
+        for skill in self.skill_keywords:
             if skill in text:
                 features['skills'].append(skill)
         

--- a/train_production.py
+++ b/train_production.py
@@ -1,0 +1,40 @@
+import os
+import argparse
+from src.utils.cv_processor import CVProcessor
+from src.models.cv_classifier import CVClassifier
+
+
+def load_cvs(data_dir):
+    """Carga y procesa CVs desde subcarpetas por profesión."""
+    processor = CVProcessor(skill_keywords=[])  # sin keywords de habilidades
+    all_data = []
+    for profession in os.listdir(data_dir):
+        prof_path = os.path.join(data_dir, profession)
+        if os.path.isdir(prof_path):
+            results = processor.process_cv_folder(prof_path, profession)
+            all_data.extend(results)
+    return all_data
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Entrena un clasificador de CVs")
+    parser.add_argument("data_dir", help="Directorio con subcarpetas de CVs por profesion")
+    parser.add_argument("--model-name", default="cv_classifier", help="Nombre del modelo a guardar")
+    parser.add_argument("--model-type", default="random_forest",
+                        choices=["random_forest", "logistic_regression", "svm", "naive_bayes"],
+                        help="Algoritmo de clasificacion")
+    args = parser.parse_args()
+
+    cv_data = load_cvs(args.data_dir)
+    if not cv_data:
+        print("No se encontraron CVs para entrenar")
+        return
+
+    classifier = CVClassifier()
+    classifier.train_model(cv_data, model_type=args.model_type)
+    classifier.save_model(args.model_name)
+    print("Modelo guardado correctamente")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- allow configuring skill keywords in `CVProcessor`
- provide docs for customizing or disabling skill keyword detection
- add simple `train_production.py` script for quick training without skills

## Testing
- `pytest -q` *(fails: ModuleNotFoundError & missing GUI dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_683fc7429554832cb91e302d16043e48