### PR TITLE
Add Flask web interface with Driver Booster style

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -48,3 +48,4 @@ matplotlib
 
 # tensorflow
 # transformers
+Flask

--- a/web_flask/app.py
+++ b/web_flask/app.py
@@ -1,0 +1,54 @@
+from flask import Flask, render_template, request, redirect, url_for, flash
+from werkzeug.utils import secure_filename
+import os
+
+from src.utils.cv_processor import CVProcessor
+from src.models.cv_classifier import CVClassifier
+
+app = Flask(__name__)
+app.secret_key = "cv-classifier-secret"
+
+UPLOAD_FOLDER = os.path.join(os.path.dirname(__file__), 'uploads')
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+# Cargar modelo por defecto si existe
+MODEL_NAME = 'cv_classifier'
+classifier = CVClassifier()
+model_loaded = classifier.load_model(MODEL_NAME)
+
+@app.route('/')
+def index():
+    return render_template('index.html', model_loaded=model_loaded)
+
+@app.route('/classify', methods=['POST'])
+def classify():
+    if 'cv_file' not in request.files:
+        flash('No se ha seleccionado archivo')
+        return redirect(url_for('index'))
+
+    file = request.files['cv_file']
+    if file.filename == '':
+        flash('Nombre de archivo vacío')
+        return redirect(url_for('index'))
+
+    filename = secure_filename(file.filename)
+    file_path = os.path.join(UPLOAD_FOLDER, filename)
+    file.save(file_path)
+
+    processor = CVProcessor()
+    text = processor.extract_text_from_file(file_path)
+    text = processor.clean_text(text)
+
+    if not model_loaded:
+        flash('No hay modelo cargado. Entrena uno y colócalo en la carpeta models.')
+        return redirect(url_for('index'))
+
+    result = classifier.predict_cv(text)
+    profession = result.get('predicted_profession', 'N/A')
+    confidence = result.get('confidence_percentage', '0%')
+    ranking = result.get('profession_ranking', [])
+    return render_template('result.html', profession=profession,
+                           confidence=confidence, ranking=ranking)
+
+if __name__ == '__main__':
+    app.run(debug=True)

--- a/web_flask/static/style.css
+++ b/web_flask/static/style.css
@@ -1,0 +1,77 @@
+body.db-theme {
+    background-color: #1d1d1d;
+    color: #ffffff;
+    font-family: Arial, Helvetica, sans-serif;
+    text-align: center;
+}
+
+.title {
+    color: #d1001f;
+    margin-top: 40px;
+}
+
+.container {
+    margin-top: 60px;
+}
+
+.upload-form {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 20px;
+    margin-top: 40px;
+}
+
+.upload-btn {
+    background-color: #323232;
+    color: #ffffff;
+    padding: 10px 20px;
+    border-radius: 5px;
+    cursor: pointer;
+}
+
+.upload-btn input {
+    display: none;
+}
+
+.scan-btn {
+    width: 160px;
+    height: 160px;
+    border-radius: 80px;
+    background-color: #d1001f;
+    color: #ffffff;
+    font-size: 20px;
+    border: none;
+}
+
+.scan-btn:hover {
+    background-color: #e51b2a;
+}
+
+.back-btn {
+    color: #d1001f;
+    text-decoration: none;
+    margin-top: 20px;
+    display: inline-block;
+}
+
+.ranking {
+    margin: 20px auto;
+    border-collapse: collapse;
+}
+
+.ranking th,
+.ranking td {
+    border: 1px solid #444444;
+    padding: 8px 12px;
+}
+
+.flash {
+    color: #d1001f;
+    margin-top: 20px;
+}
+
+.warning {
+    color: #d1001f;
+    margin-top: 20px;
+}

--- a/web_flask/templates/index.html
+++ b/web_flask/templates/index.html
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Clasificador de CVs</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="db-theme">
+    <h1 class="title">Clasificador de CVs</h1>
+    <div class="container">
+        {% if model_loaded %}
+        <form class="upload-form" action="{{ url_for('classify') }}" method="post" enctype="multipart/form-data">
+            <label class="upload-btn">Seleccionar CV
+                <input type="file" name="cv_file" accept=".pdf,.doc,.docx,.txt" required>
+            </label>
+            <button class="scan-btn" type="submit">Clasificar</button>
+        </form>
+        {% else %}
+        <p class="warning">Modelo no disponible. Entrena uno y colócalo en la carpeta <code>models</code>.</p>
+        {% endif %}
+        {% with messages = get_flashed_messages() %}
+        {% if messages %}
+        <div class="flash">{{ messages[0] }}</div>
+        {% endif %}
+        {% endwith %}
+    </div>
+</body>
+</html>

--- a/web_flask/templates/result.html
+++ b/web_flask/templates/result.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+    <meta charset="UTF-8">
+    <title>Resultado</title>
+    <link rel="stylesheet" href="{{ url_for('static', filename='style.css') }}">
+</head>
+<body class="db-theme">
+    <h1 class="title">Resultado</h1>
+    <div class="container">
+        <p class="profession">Profesión predicha: <strong>{{ profession }}</strong></p>
+        <p class="confidence">Confianza: <strong>{{ confidence }}</strong></p>
+        <table class="ranking">
+            <tr><th>Profesión</th><th>Probabilidad</th></tr>
+            {% for item in ranking %}
+            <tr><td>{{ item.profession }}</td><td>{{ item.percentage }}</td></tr>
+            {% endfor %}
+        </table>
+        <a class="back-btn" href="{{ url_for('index') }}">Volver</a>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a new `web_flask` folder with a small Flask app
- implement Driver Booster-inspired styles and templates
- extend requirements with Flask

## Testing
- `python main.py --test`

------
https://chatgpt.com/codex/tasks/task_e_683fdbb9486c832c838ef687032bdbaf